### PR TITLE
Added support for ruby >= 2.0

### DIFF
--- a/app/models/carddav/address_book_collection_resource.rb
+++ b/app/models/carddav/address_book_collection_resource.rb
@@ -17,11 +17,11 @@ class Carddav::AddressBookCollectionResource < Carddav::AddressBookBaseResource
     end
   end
 
-  protected
-
   def setup
     super
   end
+
+  protected
 
   ## Properties follow in alphabetical order
   prop :creation_date do

--- a/app/models/carddav/base_resource.rb
+++ b/app/models/carddav/base_resource.rb
@@ -132,7 +132,8 @@ class Carddav::BaseResource < DAV4Rack::Resource
       # The base dav4rack handler will use nicer looking function names for some properties
       # Let's just humor it.  If we don't define a local prop_foo method, fall back to the
       # super class's implementation of get_property which we hope will handle our request.
-      if self.respond_to?(fn)
+      # Ruby 2.x needs additional argument to respond_to? in order to check protected methods
+      if self.respond_to?(fn, RUBY_VERSION.to_i >= 2 ? true : false)
         if element[:children].empty? and element[:attributes].empty?
           return self.send(fn.to_sym)
         else
@@ -170,7 +171,8 @@ class Carddav::BaseResource < DAV4Rack::Resource
       # The base dav4rack handler will use nicer looking function names for some properties
       # Let's just humor it.  If we don't define a local prop_foo method, fall back to the
       # super class's implementation of get_property which we hope will handle our request.
-      if self.respond_to?(fn)
+      # Ruby 2.x needs additional argument to respond_to? in order to check protected methods
+      if self.respond_to?(fn, RUBY_VERSION.to_i >= 2 ? true : false)
         return self.send(fn.to_sym, element[:attributes], value)
       end
     end

--- a/lib/tasks/first_run.rake
+++ b/lib/tasks/first_run.rake
@@ -7,18 +7,19 @@ namespace :meishi do
 
     # 40 through 126 allows us to easily exclude ASCII characteres that
     # would need to be escaped in a single quoted string, change as desired.
-    SALT_CHAR_RANGE=40..126
+    # Skip ASCII code 47 (backslash char), to avoid possible escaping of last single quote in generated string
+    SALT_CHAR_ARRAY=(40..126).to_a - [47]
 
     STDOUT.puts "Generating session secret"
     sess_secret = ''
     SALT_SIZE.times do
-      sess_secret << rand(SALT_CHAR_RANGE).chr
+      sess_secret << SALT_CHAR_ARRAY.sample.chr
     end
 
     STDOUT.puts "Generating user password salt"
     pass_secret = ''
     SALT_SIZE.times do
-      pass_secret << rand(SALT_CHAR_RANGE).chr
+      pass_secret << SALT_CHAR_ARRAY.sample.chr
     end
 
     STDOUT.puts "Saving salts"


### PR DESCRIPTION
I noticed that some respond_to checks didn't work after upgrade to ruby 2.1. Turns out there [was a change to detect callable protected methods in ruby 2.0](http://tenderlovemaking.com/2012/09/07/protected-methods-and-ruby-2-0.html)

Also fixed a possible escaping of last quote in the generated salt strings

```
secret_token = 'Z(W....42_1\'
                           ^
```
